### PR TITLE
Don't hide the site title when the 'site_logo_header_text' theme mod doesn't exist.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -154,8 +154,10 @@ function site_logo_header_text_styles() {
 		return;
 	}
 
+	$header_text = get_theme_mod( 'site_logo_header_text' );
+
 	// Is Display Header Text unchecked? If so, we need to hide our header text.
-	if ( ! get_theme_mod( 'site_logo_header_text' ) ) {
+	if ( false !== $header_text && ! $header_text ) {
 		$classes = site_logo_get_header_text_classes();
 		?>
 		<!-- Site Logo: hide header text -->


### PR DESCRIPTION
When activating a theme for the first time, the `site_logo_header_text` theme mod returns `false` which causes the CSS snippet hiding the site title to be printed. Without a site title or a site logo, the header in many themes appears to be broken.

This change checks to see if the header text theme mod has been saved for the current theme before determining if the site title should be hidden.
