### PR TITLE
Add support for site logo control descriptions.

### DIFF
--- a/css/site-logo-control.css
+++ b/css/site-logo-control.css
@@ -38,3 +38,9 @@
 #customize-control-site_logo .change {
 	float: right;
 }
+
+#customize-control-site_logo .customize-control-description {
+	display: block;
+	clear: both;
+	padding-top: 6px;
+}

--- a/inc/class-site-logo-control.php
+++ b/inc/class-site-logo-control.php
@@ -30,6 +30,9 @@ class Site_Logo_Image_Control extends WP_Customize_Control {
 	// the type of files that should be allowed by the media modal
 	public $mime_type = 'image';
 
+	// custom control descriptions
+	public $description = '';
+
 	public function enqueue() {
 		// enqueues all needed media resources
 		wp_enqueue_media();
@@ -66,5 +69,8 @@ class Site_Logo_Image_Control extends WP_Customize_Control {
 		?>
 		<div class="current"></div>
 		<div class="actions"></div>
+		<?php if ( ! empty( $this->description ) ) : ?>
+			<span class="description customize-control-description"><?php echo $this->description; ?></span>
+		<?php endif; ?>
 	<?php }
 }


### PR DESCRIPTION
WordPress 4.0 now supports these for Core-supported controls, so plugins that extend the Customizer should also allow them for more contextual help with theme integrations. This fixes https://github.com/Automattic/site-logo/issues/2.
