### PR TITLE
Update template-tags.php

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -72,7 +72,7 @@ function the_site_logo() {
 	// Bail if no logo is set. Leave a placeholder if we're in the Customizer, though (needed for the live preview).
 	if ( ! isset( $logo['id'] ) || 0 == $logo['id'] ) {
 		if ( site_logo_is_customize_preview() ) {
-			printf( '<a href="%1$s"><img class="site-logo" data-size="%2$s" style="display:none;" /></a>',
+			printf( '<a href="%1$s" class="site-logo"><img data-size="%2$s" style="display:none;" /></a>',
 				esc_url( home_url( '/' ) ),
 				esc_attr( $size )
 			);


### PR DESCRIPTION
I think giving the anchor the class will be much more flexible than using the image. You can still target the image specifically using .site-logo img, and you can target the wrapper.

The other option (to save breaking existing themes) would be to add a new class to the anchor (perhaps .site-logo-wrapper).
