### PR TITLE
Update template-tags.php

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -81,14 +81,14 @@ function the_site_logo() {
 	}
 
 	// We have a logo. Logo is go.
-	$html = sprintf( '<a href="%1$s" rel="home">%2$s</a>',
+	$html = sprintf( '<a href="%1$s" rel="home" class="site-logo">%2$s</a>',
 		esc_url( home_url( '/' ) ),
 		wp_get_attachment_image(
 			$logo['id'],
 			$size,
 			false,
 			array(
-				'class'     => "site-logo attachment-$size",
+				'class'     => "attachment-$size",
 				'data-size' => $size,
 			)
 		)


### PR DESCRIPTION
I think giving the anchor the class will be much more flexible than using the image. You can still target the image specifically using .site-logo img, and you can target the wrapper.

The other option (to save breaking existing themes) would be to add a new class to the anchor (perhaps .site-logo-wrapper).
