### PR TITLE
Code review

### DIFF
--- a/inc/class-site-logo-control.php
+++ b/inc/class-site-logo-control.php
@@ -51,8 +51,6 @@ class Site_Logo_Image_Control extends WP_Customize_Control {
 	 * Enqueue our media manager resources, scripts, and styles.
 	 *
 	 * @uses wp_enqueue_media()
-	 * @uses has_action()
-	 * @uses add_action()
 	 * @uses wp_enqueue_style()
 	 * @uses wp_enqueue_script()
 	 * @uses plugins_url()
@@ -60,8 +58,6 @@ class Site_Logo_Image_Control extends WP_Customize_Control {
 	public function enqueue() {
 		// Enqueues all needed media resources.
 		wp_enqueue_media();
-		if ( ! has_action( 'customize_controls_print_footer_scripts', 'wp_print_media_templates' ) )
-			add_action( 'customize_controls_print_footer_scripts', 'wp_print_media_templates' );
 
 		// Enqueue our control script and styles.
 		wp_enqueue_style( 'site-logo-control', plugins_url( '../css/site-logo-control.css', __FILE__ ) );

--- a/js/site-logo.js
+++ b/js/site-logo.js
@@ -1,25 +1,32 @@
 (function($){
 	var api = wp.customize,
-		$logo = null,
-		$size = null;
+		$body, $anchor, $logo, size;
+
+	function cacheSelectors() {
+		$body   = $( 'body' );
+		$anchor = $( '.site-logo-anchor' );
+		$logo   = $( '.site-logo' );
+		size    = $logo.attr( 'data-size' );
+	}
 
 	api( 'site_logo', function( value ){
-		value.bind( function( newVal, oldVal ){
-			$body   = $( 'body' );
-			$anchor = $( '.site-logo-anchor' );
-			$logo   = $( '.site-logo' );
-			$size   = $logo.attr( 'data-size' );
+		value.bind( function( newVal ){
+			// grab selectors the first time through
+			if ( ! $body ) {
+				cacheSelectors();
+			}
 
 			// Let's update our preview logo.
 			if ( newVal && newVal.url ) {
 				// If the source was smaller than the size required by the theme, give the biggest we've got.
-				if ( ! newVal.sizes[ $size ] )
-					$size = 'full';
+				if ( ! newVal.sizes[ size ] ) {
+					size = 'full';
+				}
 
 				$logo.attr({
-					height: newVal.sizes[ $size ].height,
-					width: newVal.sizes[ $size ].width,
-					src: newVal.sizes[ $size ].url
+					height: newVal.sizes[ size ].height,
+					width: newVal.sizes[ size ].width,
+					src: newVal.sizes[ size ].url
 				});
 
 				$anchor.show();


### PR DESCRIPTION
Mostly this is just about fixing up some JavaScript stuff. A couple of notes:
1. JS vars need to be declared with the `var` keyword to prevent scope leaking. `$body` and `$anchor` had not been, therefore they bleed up to the global scope. This is to be avoided.
2. Using `$` to prefix a var name in JS can make the above confusing. This is a convention used by some to indicate that the value of this var is a jQuery collection. This is why I removed the prefix for `$size`, since it is not.
3. You don't need to bother with `null` for a var that you want to be empty until it's populated later. When you declare a var without a value, it automatically has the value of `undefined` which is pretty much the same thing in almost every situation.
4. It seems as though you were intending to cache some selectors for re-use, but you weren't. This now does that properly. The performance gains would likely be minimal, but it's a good practice.

Also removed the `has_action` and `add_action` stuff since core handles that properly now.
