### PR TITLE
Make preview html use same filter as output html

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -61,10 +61,11 @@ function the_site_logo() {
 	// Bail if no logo is set. Leave a placeholder if we're in the Customizer, though (needed for the live preview).
 	if ( ! has_site_logo() ) {
 		if ( site_logo_is_customize_preview() ) {
-			printf( '<a href="%1$s" class="site-logo-link" style="display:none;"><img class="site-logo" data-size="%2$s" /></a>',
+			$html = sprintf( '<a href="%1$s" class="site-logo-link" style="display:none;"><img class="site-logo" data-size="%2$s" /></a>',
 				esc_url( home_url( '/' ) ),
 				esc_attr( $size )
 			);
+			echo apply_filters( 'the_site_logo', $html );
 		}
 		return;
 	}


### PR DESCRIPTION
The reason I need this is that I updated the local copy of the site-logo plugin and the anchor link class changed - but it's not been updated on wordpress.com and so I want to use the filter to change the class on my local install so that my themes continue to work.

Not sure if this is the best way to do it since the logo and size parameters are now missing.
